### PR TITLE
added new sensor message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_message_files(
   ChargerState.msg
   ScoutStatus.msg
   MissionIdentifier.msg
+  Sensor.msg
 )
 
 

--- a/msg/Sensor.msg
+++ b/msg/Sensor.msg
@@ -1,0 +1,8 @@
+# a custom message for sensors such as IR sensor. As most of these variables are needed in general for all sensors, this can be reused in the future
+
+string sensor_name
+float64 sensor_value
+float64 threshold
+bool is_triggered
+bool is_enabled
+ 


### PR DESCRIPTION
This PR adds a new custom sensor message type. This message can be used for any future sensor publishing due to its general variables.

string sensor_name
float64 sensor_value
float64 threshold
bool is_triggered
bool is_enabled 