### PR TITLE
changed left, right, rear switch variables to one

### DIFF
--- a/msg/ScoutStatus.msg
+++ b/msg/ScoutStatus.msg
@@ -2,6 +2,4 @@ int16 mcu_state
 bool bumper_triggered
 int16 scout_state
 int16 scout_control_mode
-bool left_switch_state
-bool right_switch_state
-bool rear_switch_state
+bool switch_state


### PR DESCRIPTION
switch_state is now used instead of left_switch_state, right_switch_state, and rear_switch_state.
amended accordingly.