### PR TITLE
Add LiftState.msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_message_files(
   ChargerState.msg
   ScoutStatus.msg
   MissionIdentifier.msg
+  LiftState.msg
 )
 
 

--- a/msg/LiftState.msg
+++ b/msg/LiftState.msg
@@ -1,17 +1,17 @@
 # lift_time records when the information in this message was generated
-builtin_interfaces/Time lift_time
+time stamp
 
 string lift_name
 
 string current_floor
 
-uint8 door_state
-uint8 DOOR_CLOSED=0
-uint8 DOOR_MOVING=1
-uint8 DOOR_OPEN=2
+int16 door_state
+int16 DOOR_CLOSED=0
+int16 DOOR_MOVING=1
+int16 DOOR_OPEN=2
 
-uint8 motion_state
-uint8 MOTION_STOPPED=0
-uint8 MOTION_UP=1
-uint8 MOTION_DOWN=2
-uint8 MOTION_UNKNOWN=3
+int16 motion_state
+int16 MOTION_STOPPED=0
+int16 MOTION_UP=1
+int16 MOTION_DOWN=2
+int16 MOTION_UNKNOWN=3

--- a/msg/LiftState.msg
+++ b/msg/LiftState.msg
@@ -1,0 +1,17 @@
+# lift_time records when the information in this message was generated
+builtin_interfaces/Time lift_time
+
+string lift_name
+
+string current_floor
+
+uint8 door_state
+uint8 DOOR_CLOSED=0
+uint8 DOOR_MOVING=1
+uint8 DOOR_OPEN=2
+
+uint8 motion_state
+uint8 MOTION_STOPPED=0
+uint8 MOTION_UP=1
+uint8 MOTION_DOWN=2
+uint8 MOTION_UNKNOWN=3


### PR DESCRIPTION
## **Purpose of Pull Request** :book:  

This is in regards to allowing better tracking of lift states for Kabam Robotics' applications which contain lift-taking capabilities. 

### **Summary of Edits** :bookmark: 
- `CMakelists.txt` have been modified to add `LiftState.msg`
- `LiftState.msg` has been added under `msg/` directory.

### **Verify** :heavy_check_mark: 

Due to current lack of Continuous Integration (CI) for this repository, please run the following commands for proof that the new modification does not break the current codebase:

1. Download the modified `kabam_msgs` ROS 1 package:
```bash
cd $HOME && git clone https://github.com/cardboardcode/kabam_msgs.git --depth 1 --branch feature/add_liftstate
```

2. Compile `kabam_msgs` using Docker:
```bash
docker run -it --rm \
    -v ./kabam_msgs:/catkin_ws/src/kabam_msgs \
ros:noetic-ros-base bash -c \
"cd /catkin_ws && source /ros_entrypoint.sh && catkin_make"
```
The ROS 1 package compiles successfully before exiting the docker container.